### PR TITLE
add missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires = [
     "pyyaml",
     "requests",
     "secretstorage",
+    "url-normalize",
 ]
 
 [tool.flit.scripts]


### PR DESCRIPTION
after following install instructions, I was getting this error:

```
[crow ~/work/git/ddi](master|✔)[I]% ddi --help
Traceback (most recent call last):
  File "/home/jay/.local/bin/ddi", line 5, in <module>
    from ddi.main import main
  File "/home/jay/.local/lib/python3.8/site-packages/ddi/main.py", line 1, in <module>
    from ddi.cli import cli
  File "/home/jay/.local/lib/python3.8/site-packages/ddi/cli.py", line 8, in <module>
    import url_normalize
ModuleNotFoundError: No module named 'url_normalize'
```